### PR TITLE
Fixes bug that were skipping folder of being instrumented

### DIFF
--- a/main.go
+++ b/main.go
@@ -124,12 +124,13 @@ func processTestFile(filePath string, state interface{}) error {
 	}
 
 	tmInfoMap := *(state.(*map[string]*testPackageInfo))
+	packageName := fileParser.Name.Name
 	folder := path.Dir(filePath)
-	key := fmt.Sprintf("%s.%s", folder, fileParser.Name.Name)
+	key := fmt.Sprintf("%s.%s", folder, packageName)
 	tpi := tmInfoMap[key]
 	if tpi == nil {
 		tpi = &testPackageInfo{
-			Name:         fileParser.Name.Name,
+			Name:         packageName,
 			Folder:       folder,
 			MainFile:     nil,
 			Instrumented: false,

--- a/main.go
+++ b/main.go
@@ -124,16 +124,18 @@ func processTestFile(filePath string, state interface{}) error {
 	}
 
 	tmInfoMap := *(state.(*map[string]*testPackageInfo))
-	tpi := tmInfoMap[fileParser.Name.Name]
+	folder := path.Dir(filePath)
+	key := fmt.Sprintf("%s.%s", folder, fileParser.Name.Name)
+	tpi := tmInfoMap[key]
 	if tpi == nil {
 		tpi = &testPackageInfo{
 			Name:         fileParser.Name.Name,
-			Folder:       path.Dir(filePath),
+			Folder:       folder,
 			MainFile:     nil,
 			Instrumented: false,
 			Skipped:      false,
 		}
-		tmInfoMap[fileParser.Name.Name] = tpi
+		tmInfoMap[key] = tpi
 	}
 
 	for _, decl := range fileParser.Decls {


### PR DESCRIPTION
This `PR` fixes a bug that were skipping folder of being instrumented with the same package name.

Before the map key of the package info was based on the package name, causing to skip the instrumentation of a packages with the same name but in a different path.

This `PR` changes the key with a new one with the `{FolderPath}.{PackageName}` to avoid the collision.